### PR TITLE
removed upper bound on vector version

### DIFF
--- a/aur.cabal
+++ b/aur.cabal
@@ -69,7 +69,7 @@ library
                        lens-aeson,
                        mtl >=2.1 && <3,
                        text >=1.1 && <1.3,
-                       vector >=0.10 && <0.11,
+                       vector >=0.10,
                        wreq >=0.4
   
   -- Directories containing source files.


### PR DESCRIPTION
As of 2015-08-03, the version requirements of vector for this library (>.10 && <.11) no longer match the current version of haskell-vector in either the [haskell-core] or [community] arch repositories (.11).  This makes haskell-aur and aura currently nonviable for up-to-date arch systems.

With the upper bound removed, library still builds cleanly.